### PR TITLE
Add option to configure bucket prefix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ node_modules
 .node_repl_history
 
 .DS_Store
+
+config.js

--- a/config.example.js
+++ b/config.example.js
@@ -9,6 +9,7 @@ module.exports = {
   serverURL: "https://api.customparseserver.com/parse",
   filesToTransfer: 'parseOnly',
   renameInDatabase: false,
+  transferTo: 'filesystem',
 
   // For filesystem configuration
   filesystemPath: './downloaded_files',
@@ -17,6 +18,7 @@ module.exports = {
   aws_accessKeyId: "ACCESS_KEY_ID",
   aws_secretAccessKey: "SECRET_ACCESS_KEY",
   aws_bucket: "BUCKET_NAME",
+  aws_bucketPrefix: "",
 
   // For GCS configuration
   gcs_projectId: "GCS_PROJECT_ID",

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -94,7 +94,8 @@ function questions(config) {
         return (answers.transferTo == 's3' || config.transferTo == 's3') &&
                !config.aws_accessKeyId &&
                !config.aws_profile;
-      }
+      },
+      default: process.env.AWS_ACCESS_KEY_ID
     }, {
       type: 'input',
       name: 'aws_secretAccessKey',
@@ -103,7 +104,8 @@ function questions(config) {
         return (answers.transferTo == 's3' || config.transferTo == 's3') &&
                !config.aws_secretAccessKey &&
                !config.aws_profile;
-      }
+      },
+      default: process.env.AWS_SECRET_ACCESS_KEY
     }, {
       type: 'input',
       name: 'aws_bucket',
@@ -111,6 +113,15 @@ function questions(config) {
       when: function(answers) {
         return (answers.transferTo == 's3' || config.transferTo == 's3') &&
                !config.aws_bucket;
+      }
+    },
+    {
+      type: 'input',
+      name: 'aws_bucketPrefix',
+      message: 'S3 bucket prefix (optional)',
+      when: function (answers) {
+        return (answers.transferTo == 's3' || config.transferTo == 's3') &&
+          !config.aws_bucketPrefix;
       }
     },
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -10,7 +10,7 @@ function get() {
        headers: {
          'Content-Type': 'application/json',
          'X-Parse-Application-Id': Parse.applicationId,
-         'X-Parse-Master-Key': Parse.masterKey 
+         'X-Parse-Master-Key': Parse.masterKey
        }
       }, function(err, res, body) {
         if (err) {

--- a/lib/transfer.js
+++ b/lib/transfer.js
@@ -50,6 +50,7 @@ function _setup() {
       accessKey: config.aws_secretAccessKey,
       secretKey: config.aws_secretAccessKey,
       bucket: config.aws_bucket,
+      bucketPrefix: config.aws_bucketPrefix,
       directAccess: true
     });
   } else if (config.transferTo == 'gcs') {


### PR DESCRIPTION
1. Add bucket prefix config option
2. Also add default answer for AWS_\* info.

AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY are standard env vars that all AWS clients look for.  Add them as defaults to make it easier to configure.
