### PR TITLE
Return the error instead of the string Error.

### DIFF
--- a/lib/transfer.js
+++ b/lib/transfer.js
@@ -120,7 +120,7 @@ function _processFiles(files, handler) {
       }
     }, function(error) {
       if (error) {
-        return reject('\nError!', error);
+        return reject(error);
       }
       resolve('\nComplete!');
     });


### PR DESCRIPTION
Promise.reject takes one argument.  The result of this change is to print the actual error
instead of the string error.
