### PR TITLE
Fix Parse file renaming so tfss- files don't become legacy files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ $ npm start config.js
 * `masterKey`: Parse master key.
 * `serverURL`: The URL for the Parse server (default: http://api.parse.com/1). 
 This is used to with `applicationId` and `masterKey` to get the schema and fetch all files/objects.
+* `renameFiles` (boolean): Whether or not to rename Parse hosted files. 
+This removes the "tfss-" or legacy Parse filename prefix before saving with the new file adapter.
 * `renameInDatabase` (boolean): Whether or not to rename files in MongoDB.
 * `mongoURL`: MongoDB connection url. 
 Direct access to the database is needed because Parse SDK doesn't allow direct writing to file fields.

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -36,11 +36,22 @@ function questions(config) {
       when: (['parseOnly','parseServerOnly', 'all'].indexOf(config.filesToTransfer) == -1)
     }, {
       type: 'confirm',
+      name: 'renameFiles',
+      message: 'Rename Parse hosted file names?',
+      default: false,
+      when: function(answers) {
+        return config.renameFiles == undefined &&
+               (answers.filesToTransfer == 'all' || config.filesToTransfer == 'all' ||
+               config.filesToTransfer == 'parseOnly' || answers.filesToTransfer == 'parseOnly');
+      }
+    }, {
+      type: 'confirm',
       name: 'renameInDatabase',
       message: 'Rename Parse hosted files in the database after transfer?',
       default: false,
       when: function(answers) {
-        return !config.renameInDatabase &&
+        return config.renameInDatabase == undefined &&
+               (answers.renameFiles || config.renameFiles) &&
                (answers.filesToTransfer == 'all' || config.filesToTransfer == 'all' ||
                config.filesToTransfer == 'parseOnly' || answers.filesToTransfer == 'parseOnly');
       }

--- a/lib/transfer.js
+++ b/lib/transfer.js
@@ -8,6 +8,7 @@ var MongoClient = require('mongodb').MongoClient;
 
 // regex that matches old legacy Parse hosted files
 var legacyFilesPrefixRegex = new RegExp("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}-");
+var migratedFilePrefix = 'mfp_';
 
 var db, config;
 
@@ -90,15 +91,20 @@ function _requestErrorHandler(error, response) {
  * @param  {String} fileName
  * @return {String}
  */
-function _nonParseFileName(fileName) {
-  if (fileName.indexOf('tfss-') === 0) {
+function _createNewFileName(fileName) {
+  if (_isParseHostedFile(fileName)) {
     fileName = fileName.replace('tfss-', '');
-  }
-  if (legacyFilesPrefixRegex.test(fileName)) {
     var newPrefix = crypto.randomBytes(32/2).toString('hex');
     fileName = newPrefix + fileName.replace(legacyFilesPrefixRegex, '');
   }
-  return fileName;
+  return migratedFilePrefix + fileName;
+}
+
+function _isParseHostedFile(fileName) {
+  if (fileName.indexOf('tfss-') === 0 || legacyFilesPrefixRegex.test(fileName)) {
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -112,7 +118,7 @@ function _processFiles(files, handler) {
   return new Promise(function(resolve, reject) {
     async.eachOfLimit(files, asyncLimit, function(file, index, callback) {
       process.stdout.write('Processing '+(index+1)+'/'+files.length+'\r');
-      file.newFileName = _nonParseFileName(file.fileName);
+      file.newFileName = _createNewFileName(file.fileName);
       if (_shouldTransferFile(file)) {
         _transferFile(file).then(callback, callback);
       } else {
@@ -160,12 +166,12 @@ function _shouldTransferFile(file) {
     return true;
   } else if (
     config.filesToTransfer == 'parseOnly' &&
-    file.fileName != file.newFileName
+    _isParseHostedFile(file.fileName)
   ) {
     return true;
   } else if (
     config.filesToTransfer == 'parseServerOnly' &&
-    file.fileName == file.newFileName
+    !_isParseHostedFile(file.fileName)
   ) {
     return true;
   }

--- a/lib/transfer.js
+++ b/lib/transfer.js
@@ -92,6 +92,9 @@ function _requestErrorHandler(error, response) {
  * @return {String}
  */
 function _createNewFileName(fileName) {
+  if (!config.renameFiles) {
+    return fileName;
+  }
   if (_isParseHostedFile(fileName)) {
     fileName = fileName.replace('tfss-', '');
     var newPrefix = crypto.randomBytes(32/2).toString('hex');

--- a/lib/transfer.js
+++ b/lib/transfer.js
@@ -92,13 +92,13 @@ function _requestErrorHandler(error, response) {
  */
 function _nonParseFileName(fileName) {
   if (fileName.indexOf('tfss-') === 0) {
-    return fileName.replace('tfss-', '');
-  } else if (legacyFilesPrefixRegex.test(fileName)) {
-    var newPrefix = crypto.randomBytes(32/2).toString('hex');
-    return newPrefix + fileName.replace(legacyFilesPrefixRegex, '');
-  } else {
-    return fileName;
+    fileName = fileName.replace('tfss-', '');
   }
+  if (legacyFilesPrefixRegex.test(fileName)) {
+    var newPrefix = crypto.randomBytes(32/2).toString('hex');
+    fileName = newPrefix + fileName.replace(legacyFilesPrefixRegex, '');
+  }
+  return fileName;
 }
 
 /**


### PR DESCRIPTION
Addresses issue mentioned in comments of [PR #7](https://github.com/parse-server-modules/parse-files-utils/pull/7#issuecomment-234084860)

> Example:
> - original url: http://files.parsetfss.com/75b8d55e-cb49-4169-8aa8-51c3252d7031/tfss-0e4d6293-5f8b-4382-be05-30ddb1cc686f-photo.jpeg
> - filename: tfss-0e4d6293-5f8b-4382-be05-30ddb1cc686f-photo.jpeg
> - new filename after renaming: 0e4d6293-5f8b-4382-be05-30ddb1cc686f-photo.jpeg
> - new url: http://files.parse.com/75b8d55e-cb49-4169-8aa8-51c3252d7031/0e4d6293-5f8b-4382-be05-30ddb1cc686f-photo.jpeg
> 
> Then, Parse Server runs [this code](https://github.com/ParsePlatform/parse-server/blob/master/src/Controllers/FilesController.js#L63-L76) and determines that the new filename is hosted on Parse's legacy file server 😖 
