### PR TITLE
Correctly locate all documents with files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,7 +47,10 @@ function getAllFileObjects() {
   }).then(function(results) {
     var files = results.reduce(function(c, r) {
       return c.concat(r);
-    }, []);
+    }, []).filter(function(file) {
+      return file.fileName !== 'DELETE';
+    });
+
     return Promise.resolve(files);
   });
 }
@@ -90,19 +93,24 @@ function getObjectsWithFilesFromSchema(schema) {
   query.select(schema.fields.concat('createdAt'));
   query.ascending('createdAt');
   query.limit(1000);
-  schema.fields.forEach(function(field) {
-    query.exists(field);
+
+  var checks = schema.fields.map(function(field) {
+      return new Parse.Query(schema.className).exists(field);
   });
+  query._orQuery(checks);
+
   return getAllObjects(query).then(function(results) {
     return results.reduce(function(current, result){
       return current.concat(
         schema.fields.map(function(field){
+          var fName = result.get(field) ? result.get(field).name() : 'DELETE';
+          var fUrl = result.get(field) ? result.get(field).url() : 'DELETE';
           return {
             className: schema.className,
             objectId: result.id,
             fieldName: field,
-            fileName: result.get(field).name(),
-            url: result.get(field).url()
+            fileName: fName,
+            url: fUrl
           }
         })
       );


### PR DESCRIPTION
At the moment, the Parse query implements a where conditional that only includes documents where each file field contains a file. This means that for documents with multiple fields with the type FILE, if just one field is undefined all other files for that document will be excluded from the resulting Parse query.

This fix does two things. Firstly it implements an OR conditional to ensure that documents with multiple file fields, some containing files and some undefined, will be included in the search. Secondly, it filters this list to remove undefined file objects.
