### PR TITLE
added azure to when check for transferTo

### DIFF
--- a/lib/questions.js
+++ b/lib/questions.js
@@ -79,7 +79,7 @@ function questions(config) {
         {name: 'Azure Blob Storage', value: 'azure'},
       ],
       when: function() {
-        return (['print','filesystem','s3','gcs'].indexOf(config.transferTo) == -1) &&
+        return (['print','filesystem','s3','gcs','azure'].indexOf(config.transferTo) == -1) &&
                !config.filesAdapter
       }
     },


### PR DESCRIPTION
This check was missing the case for config.transferTo === 'azure' and results in user having to interactively select Azure Blob Storage even when already set in config.js.