### PR TITLE
replace domain name with direct S3 access

### DIFF
--- a/lib/transfer.js
+++ b/lib/transfer.js
@@ -192,6 +192,13 @@ function _shouldTransferFile(file) {
   return false;
 }
 
+function _replaceDomainName(url) {
+  url = url.replace(/http(s)?:\/\/filescdn\.parsetfss\.com\//, 'https://s3.amazonaws.com/files.parsetfss.com/');
+  url = url.replace(/http(s)?:\/\/files\.parsetfss\.com\//, 'https://s3.amazonaws.com/files.parsetfss.com/');
+  url = url.replace(/http(s)?:\/\/files\.parse\.com\//, 'https://s3.amazonaws.com/files.parse.com/');
+  return url;
+}
+
 /**
  * Request file from URL and upload with filesAdapter
  * @param  {Object}   file     the file info object
@@ -203,7 +210,7 @@ function _transferFile(file) {
       // Use process.nextTick to avoid max call stack error
       return process.nextTick(resolve);
     }
-    request({ url: file.url, encoding: null }, function(error, response, body) {
+    request({ url: _replaceDomainName(file.url), encoding: null }, function(error, response, body) {
       if (_requestErrorHandler(error, response)) {
         return reject(error);
       }


### PR DESCRIPTION
files.parsetfss.com, files.parse.com, etc. are now down. You can still access files on those hosts if you use the S3 bucket names (for now--these buckets will be taken down soon).

this is an untested diff which replaces `https://files.parsetfss.com` with `https://s3.amazonaws.com/files.parsetfss.com`, etc.